### PR TITLE
require parens in arrow function

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     }],
     "new-cap": ["error", {
       "capIsNew": false
-    }]
+    }],
+    "arrow-parens": ["error", "always"]
   }
 };


### PR DESCRIPTION
## arrow functionの引数をカッコで囲むように

現状のルールでは、arrow functionの引数にカッコを付けると怒られてました。

``` javascript
/Users/hirakiuc/repos/src/github.com/leonis/irow-lambda-logger/lib/irow_extend.js
   9:23  error  Unexpected parentheses around single function argument  arrow-parens

  4 const extend = (log4js) => {
  5   const logger = log4js.getLogger();
  6   const base = logger.constructor.prototype;
```

=> 4行目の`log4js`を囲むカッコを付けるな、と怒られてる。
## お気持ち

個人的には、引数であることを明示する意味でも付けた方がいいと考えますので、pull reqにしました。
## 変更内容

`arrow-parens`のオプションはいくつかあるようですが、厳しめな`always`にしてます。

Ref: [arrow-parensのruleのドキュメント]
