### PR TITLE
Enable prefer-template rule.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
       "destructuring": "any",
       "ignoreReadBeforeAssign": false
     }],
+    "prefer-template": ["error"],
     "no-var": 2,
     "camelcase": ["error", {
       "properties": "never"


### PR DESCRIPTION
eslintの[prefer-template](http://eslint.org/docs/rules/prefer-template) を有効にしました。

`文字列を連結するときはバッククオートをつかったtemplate literalで書くように`というルールです。

=> http://eslint.org/docs/rules/prefer-template

## 変更の理由

- node.js 4.3.2 で既にsupportされてるぽい
- (不都合の無い範囲で) できるだけES6に寄せていきたい 🙏 