### PR TITLE
Enable more longer line.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ module.exports = {
     "max-len": ["error", {
       "code": 100,
       "ignoreComments": true,
-      "ignoreUrls": true
+      "ignoreUrls": true,
+      "ignoreTemplateLiterals": true
     }]
   }
 };

--- a/index.js
+++ b/index.js
@@ -15,6 +15,11 @@ module.exports = {
     "new-cap": ["error", {
       "capIsNew": false
     }],
-    "arrow-parens": ["error", "always"]
+    "arrow-parens": ["error", "always"],
+    "max-len": ["error", {
+      "code": 100,
+      "ignoreComments": true,
+      "ignoreUrls": true
+    }]
   }
 };


### PR DESCRIPTION
## `max-len` ruleを緩和しました

Ref: http://eslint.org/docs/rules/max-len

現状では(default値の)80文字制限が入ってますが、もう少し長くても良さそうなので緩和する方向にルールを変更してます。 

- コードは1行100文字まで
- `コメント`と`URL`を長さチェックの対象から外す

### 備考

コメントとURLをチェック対象から外してるのは、以下の気持ちから。

- コメントやURLは、無理に改行すると、読みづらくなりそうなため
   - コメントは区切り見つけられれば極力改行できそうですが、区切りが悪いときもありそうですし