### PR TITLE
Enable testcase lint

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@
 
 module.exports = {
   extends: 'google',
+  env: {
+    node: true,
+    es6: true,
+    mocha: true
+  },
   rules: {
     "prefer-const": ["error", {
       "destructuring": "any",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-leonis",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "ESLint config for Leonis&Co. projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# mochaのtestcaseをeslintでcheckできるように

[eslintのdocument](http://eslint.org/docs/user-guide/configuring#specifying-environments)を参考に`env`設定を調整しました。

## 変更内容

- eslintの設定`env`に`mocha: true`を追加

### 補足

eslint-config-googleのbaseになっている[eslint-config-xoをちら見](https://github.com/sindresorhus/eslint-config-xo/blob/master/index.js#L12)したところ、`node`と`es6`が有効になってました。

```
env: {
  node: true,
  es6: true
}
```

eslint-config-googleでは特に変更されてなかったため、このpull reqではそこに`mocha`を追加してます。

## 備考

この変更により、以下のようなerrorがでなくなります。

```
(...snipped...)
   9:1   error  'describe' is not defined                                                                                      no-undef
  12:3   error  'describe' is not defined                                                                                      no-undef
  15:5   error  'before' is not defined                                                                                        no-undef
  20:5   error  'it' is not defined                                                                                            no-undef
  25:3   error  'describe' is not defined                                                                                      no-undef
  28:5   error  'before' is not defined                                                                                        no-undef
  33:5   error  'it' is not defined                                                                                            no-undef
(...snipped...)
```